### PR TITLE
Import environnent variables by design

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -3,8 +3,8 @@ Class Config
 {
     public static $config = array(
         // Http auth configuration
-        'username' => "sebartyr",
-        'password' => "azerty",
+        'username' => getenv(“USERNAME”),
+        'password' => getenv(“PASSWORD”),
 
         // Storage mode (sql, csv, log)
         'mode' => 'csv',
@@ -15,11 +15,11 @@ Class Config
         // Database parameters
         'db' => array(
             'mode' => 'mysql', // mysql or pgsql
-            'host'=> "localhost",
-            'port' => "3306",
-            'dbname' => "http-logs-drain",
-            'username' => "root",
-            'password' => "",
+            'host'=> getenv(“MYSQL_ADDON_HOST”),
+            'port' => getenv(“MYSQL_ADDON_PORT”),
+            'dbname' => getenv(“MYSQL_ADDON_DB”),
+            'username' => getenv(“MYSQL_ADDON_USER”),
+            'password' => getenv(“MYSQL_ADDON_PASSWORD”),
             'table' => "logs"
             )
     );


### PR DESCRIPTION
Instead of leaving environment variables in configuration file, add the code to import them and specify the environment variables to set up in Clever Cloud.